### PR TITLE
Set `PYENV_COMMAND_PATH` even if multiple candidate versions found.

### DIFF
--- a/etc/pyenv.d/which/whence.bash
+++ b/etc/pyenv.d/which/whence.bash
@@ -1,6 +1,9 @@
 if [ -n "$PYENV_COMMAND" ] && [ ! -x "$PYENV_COMMAND_PATH" ]; then
   versions=($(pyenv-whence "${PYENV_COMMAND}" 2>/dev/null || true))
-  if [ "${#versions[@]}" -eq 1 ]; then
+  if [ -n "${versions}" ]; then
+    if [ "${#versions[@]}" -gt 1 ]; then
+      echo "pyenv-implicit: found multiple ${PYENV_COMMAND} in pyenv. Use version ${versions[0]}." 1>&2
+    fi
     PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${versions[0]}/bin/${PYENV_COMMAND}"
   fi
 fi


### PR DESCRIPTION
If multiple candidates found in pyenv, display a warning message and just choose first one for `PYENV_COMMAND_PATH`.
