### PR TITLE
Update install snippet to use pyenv root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Installing **pyenv-implict** as a pyenv plugin will give you access to the provided behavior.
 
 ```sh
-$ git clone git://github.com/concordusapps/pyenv-implict.git ~/.pyenv/plugins/pyenv-implict
+$ git clone git://github.com/concordusapps/pyenv-implict.git $(pyenv root)/plugins/pyenv-implict
 ```
 
 ## Usage


### PR DESCRIPTION
This is quite helpful if you're installing Pyenv into a non-standard location, and/or using a helper like Anyenv or similar.